### PR TITLE
FIXED bug duplicate Liste'IDs in sync init response 

### DIFF
--- a/java/org/dmb/trueprice/filter/RestrictionFilter.java
+++ b/java/org/dmb/trueprice/filter/RestrictionFilter.java
@@ -505,12 +505,12 @@ public final class RestrictionFilter implements Filter {
         
 //        if (request.isSecure()) {
             
-            log.info("FILTERING REQUEST ==> Request is Secure() ? >     " + request.isSecure());
+//            log.info("FILTERING REQUEST ==> Request is Secure() ? >     " + request.isSecure());
             
             String scheme = "";
             scheme = request.getScheme();
             
-            log.info("FILTERING REQUEST ==>     Scheme          is      [" + scheme + "]");
+//            log.info("FILTERING REQUEST ==>     Scheme          is      [" + scheme + "]");
             
             String sslSessionId = "";
             sslSessionId = ServletUtils.getRequestAttrValue(request, ATT_SSL_SESSION_ID) ;
@@ -521,10 +521,10 @@ public final class RestrictionFilter implements Filter {
             
             if (sslSessionId != null) {
             
-                log.info("FILTERING REQUEST ==>     ssl Session ID  is      [" + ( sslSessionId == "" ? "Value not found ...." : sslSessionId) + "]");                
+//                log.info("FILTERING REQUEST ==>     ssl Session ID  is      [" + ( sslSessionId == "" ? "Value not found ...." : sslSessionId) + "]");                
                 
             } else {
-                log.info("FILTERING REQUEST ==>     ssl Session ID  is  NULL !!");            
+//                log.info("FILTERING REQUEST ==>     ssl Session ID  is  NULL !!");            
             }
             
 //            String serverPort = "" ;
@@ -533,7 +533,7 @@ public final class RestrictionFilter implements Filter {
             
 //            if (serverPort != null) {
             
-                log.info("FILTERING REQUEST ==>     Server port     is      [" + serverPort + "]");                
+//                log.info("FILTERING REQUEST ==>     Server port     is      [" + serverPort + "]");                
                 
 //            }            
             
@@ -542,7 +542,7 @@ public final class RestrictionFilter implements Filter {
             
 //            if (serverPort != null) {
             
-                log.info("FILTERING REQUEST ==>     Request URL     is      [" + ( fullUrl == "" ? "Value not found ...." :  fullUrl) + "]");                
+//                log.info("FILTERING REQUEST ==>     Request URL     is      [" + ( fullUrl == "" ? "Value not found ...." :  fullUrl) + "]");                
                 
 //            }            
             
@@ -552,7 +552,7 @@ public final class RestrictionFilter implements Filter {
 //                    request.getRemoteUser() != null && 
                 if ( ! scheme.equals("https")) {
                     
-                    log.info("Scheme is not HTTPS : [" + scheme.toString() +"] > return false; ");
+//                    log.info("Scheme is not HTTPS : [" + scheme.toString() +"] > return false; ");
                     
                     return false;
                 } else if ( serverPort.compareTo(443) != 0 && serverPort.compareTo(8443) != 0 ) {

--- a/java/org/dmb/trueprice/handlers/ListeHandler.java
+++ b/java/org/dmb/trueprice/handlers/ListeHandler.java
@@ -625,10 +625,10 @@ public final class ListeHandler extends BasicHandler {
             
             log.info(
                 "Gonna try to modify list [" + lst.getLstLabel() + "] "
-                + "\n Description [" + lst.getLstDescription() + "]"
-                + "\n Membre ID[" + lst.getLstUser()+ "]"
-                + "\n Enseigne ID [" + lst.getLstEnseigne() + "]"
-                + "\n Produits IDs [" + lst.getLstProduits() + "]"
+//                + "\n Description [" + lst.getLstDescription() + "]"
+//                + "\n Membre ID[" + lst.getLstUser()+ "]"
+//                + "\n Enseigne ID [" + lst.getLstEnseigne() + "]"
+//                + "\n Produits IDs [" + lst.getLstProduits() + "]"
             );
             
             

--- a/java/org/dmb/trueprice/utils/internal/FileUtils.java
+++ b/java/org/dmb/trueprice/utils/internal/FileUtils.java
@@ -203,9 +203,7 @@ public abstract class FileUtils {
             
             Files.write(
                 Paths.get(targetFolder + File.separator + fileName),
-                bytes,
-                StandardOpenOption.WRITE
-//                , StandardOpenOption.CREATE_NEW
+                bytes, StandardOpenOption.WRITE
             );
 
 //        } catch ( e) {

--- a/java/org/dmb/trueprice/utils/internal/ServletUtils.java
+++ b/java/org/dmb/trueprice/utils/internal/ServletUtils.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.logging.Level;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -303,12 +304,31 @@ public abstract class ServletUtils {
 //            SyncInitResponse initResp = GsonConverter.fromJsonInitResponse(new FileReader(new File(getPath(userMail))));
             SyncInitResponse initResp = getMemberInitResponse(userMail);
             
+            // It's not enough ...
 //            initResp.getAvailableLists().put(listeId, date);
+//            initResp.getAvailableLists().add(liste);
+            // ... we need to remove the old liste before.
+            int oldListeIndex = -1 ;
+            int ct = 0 ;
+            for ( AvailableList oldListe : initResp.getAvailableLists()) {
+                log.debug("counter test = " + ct);
+                if (oldListe.getListeId() == liste.getListeId()) {
+                    oldListeIndex = initResp.getAvailableLists().indexOf(oldListe);
+                    log.debug("Old Liste index found [" + oldListeIndex +"]");
+                    break;
+                }
+                ct++;
+            }
+            // Enelever l'ancienne liste si elle existe 
+            if (oldListeIndex >= 0) {  initResp.getAvailableLists().remove(oldListeIndex);  }
+            // Ajouter la nouvelle quoi qu'il arrive
             initResp.getAvailableLists().add(liste);
             
+            // Convertir le resultat en JSon
 //            byte[] bytes = GsonConverter.toJsonTree(initResp).getBytes();
             byte[] bytes = GsonConverter.toJson(initResp).getBytes();
             
+            // L'ecrire dans le dossier du membre
             FileUtils.writeFile(SyncInitResponseFilename, bytes ,InitContextListener.getXmlMemberFullPath(userMail));
             
         } catch (Exception e) {


### PR DESCRIPTION
when the liste content change, sync init response was written with duplicate liste keeping old content.

Juste added FIX to remove the previous liste and then add the new one with up-to-date content and write the file like before.
